### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/WooDNSword/registrant.png?label=ready&title=Ready)](https://waffle.io/WooDNSword/registrant)
 # WooDNSword Registrant
 
 [![Build Status](https://travis-ci.org/WooDNSword/registrant.svg?branch=master)](https://travis-ci.org/WooDNSword/registrant)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/WooDNSword/registrant

This was requested by a real person (user xnil) on waffle.io, we're not trying to spam you.
